### PR TITLE
Solution (#12): Button tooltips drop behind the taskbar after ~1 second

### DIFF
--- a/path/to/App.xaml.cs
+++ b/path/to/App.xaml.cs
@@ -1,0 +1,10 @@
+# complete code
+import System.Windows
+
+class App(System.Windows.Application):
+    def OnStartup(self, sender, e):
+        """
+        Initialize the application.
+        """
+        self.main_window = MainWindow()
+        self.main_window.Show()

--- a/path/to/Interop.cs
+++ b/path/to/Interop.cs
@@ -1,0 +1,21 @@
+# complete code
+import System.Windows
+import System.Windows.Interop
+
+class Interop:
+    @staticmethod
+    def is_tooltip_open():
+        """
+        Check if a tooltip/popup is open.
+        """
+        try:
+            # Get the current window
+            window = System.Windows.Window.GetWindow(System.Windows.Application.Current.MainWindow)
+            # Get the tooltip service
+            tooltip_service = System.Windows.Interop.TooltipServiceFactory.GetService()
+            # Check if a tooltip is open
+            return tooltip_service.IsOpen
+        except Exception as e:
+            # Handle any exceptions
+            print(f"Error checking for open tooltip: {e}")
+            return False

--- a/path/to/MainWindow.xaml.cs
+++ b/path/to/MainWindow.xaml.cs
@@ -1,0 +1,29 @@
+# complete code
+import System.Windows
+import System.Windows.Interop
+import TaskbarAnchors
+
+class MainWindow(System.Windows.Window):
+    def __init__(self):
+        super().__init__()
+        self.taskbar_anchors = TaskbarAnchors()
+        self.is_tooltip_open = False
+
+    def OnToolTipOpen(self, sender, e):
+        """
+        Set the flag when a tooltip/popup is opened.
+        """
+        self.is_tooltip_open = True
+
+    def OnToolTipClose(self, sender, e):
+        """
+        Set the flag when a tooltip/popup is closed.
+        """
+        self.is_tooltip_open = False
+
+    def OnPositionUpdate(self, sender, e):
+        """
+        Skip topmost re-assertion while a tooltip/popup is open.
+        """
+        if not self.is_tooltip_open:
+            self.taskbar_anchors.EnsureTopmost()

--- a/path/to/SpotifyTaskbarWidget.csproj
+++ b/path/to/SpotifyTaskbarWidget.csproj
@@ -1,0 +1,30 @@
+# complete code
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>SpotifyTaskbarWidget</RootNamespace>
+    <AssemblyName>SpotifyTaskbarWidget</AssemblyName>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationIcon>app.ico</ApplicationIcon>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
+    <Version>1.2.7</Version>
+    <Product>Taskbar Widget for Spotify</Product>
+    <AssemblyTitle>Taskbar Widget for Spotify</AssemblyTitle>
+    <Company>MechanicWB</Company>
+    <!-- Um único .exe no publish, para as atualizações substituírem só um ficheiro -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Windows" />
+    <Reference Include="System.Windows.Interop" />
+  </ItemGroup>
+
+</Project>

--- a/path/to/TaskbarAnchors.cs
+++ b/path/to/TaskbarAnchors.cs
@@ -1,0 +1,15 @@
+# complete code
+import System.Windows
+import System.Windows.Interop
+import Interop
+
+class TaskbarAnchors:
+    def EnsureTopmost(self):
+        """
+        Ensure the widget is topmost, skipping re-assertion while a tooltip/popup is open.
+        """
+        if not Interop.is_tooltip_open():
+            # Get the current window
+            window = System.Windows.Window.GetWindow(System.Windows.Application.Current.MainWindow)
+            # Set the window as topmost
+            window.Topmost = True


### PR DESCRIPTION
**Fix: Button tooltips drop behind taskbar after 1 second**

This pull request addresses the issue where button tooltips drop behind the taskbar after approximately 1 second. The changes include:

* Adding a check for open tooltips/popup windows in `Interop.cs`
* Using the check in `TaskbarAnchors.cs` to skip re-asserting topmost status while a tooltip is open
* Updating `MainWindow.xaml.cs` to set a flag indicating whether a tooltip is open and using it in `OnPositionUpdate`

**Testing instructions:**

1. Clone the repository and build the project.
2. Run the application and interact with the button tooltips.
3. Observe that the tooltips no longer drop behind the taskbar after approximately 1 second.

**Changes:**

* `Interop.cs`: Added `is_tooltip_open` method to check for open tooltips/popup windows.
* `TaskbarAnchors.cs`: Updated `EnsureTopmost` method to skip re-asserting topmost status while a tooltip is open.
* `MainWindow.xaml.cs`: Added event handlers for tooltip open and close events to set a flag indicating whether a tooltip is open, and used it in `OnPositionUpdate`.